### PR TITLE
[distgen] Allow override of global JSON via ENV

### DIFF
--- a/distgen/README.md
+++ b/distgen/README.md
@@ -46,9 +46,13 @@ package dist
 
 ### Using an Environment Variable
 
-The usage of an environmental variable allows for better flexibility when dealing with CI systems.
+The usage of an environmental variable allows for better flexibility when dealing with CI systems.  
 
-The usage inside of your dist files will not change, but you can pass ENV as of your `go generate` command.
+As we saw in the previous example, the 3rd argument that is passed to `go run` is an URI, which is used to override the default JSON file for `distgen`.
+
+The `DIST_FILE` environment performs the same functionality by overloading the default JSON file.
+
+The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
 
 Example:
 ```shell script

--- a/distgen/README.md
+++ b/distgen/README.md
@@ -46,11 +46,11 @@ package dist
 
 ### Using an Environment Variable
 
-Using an environmental variable gives you more flexibility with CI systems.  
-As we saw in the custom JSON file example, passing a URI to `go run` in the third argument 
-overrides the default JSON file for `distgen`.
-The `DIST_FILE` environment performs the same function by overloading the default JSON file.
-The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
+Using an environmental variable gives you more flexibility with CI systems. As we saw in
+the custom JSON file example, passing a URI to `go run` in the third argument overrides
+the default JSON file for `distgen`. The `DIST_FILE` environment performs the same
+function by overloading the default JSON file. The usage inside of your dist files will
+not change, but you can pass ENV as a part of your `go generate` command.
 
 Example:
 ```shell script

--- a/distgen/README.md
+++ b/distgen/README.md
@@ -43,3 +43,14 @@ global variables to generate. (See an example of a JSON file at
 package dist
 //go:generate go run github.com/chef/go-libs/distgen global.go dist https://example.com/path/to/glob_dist.json
 ```
+
+### Using an Environment Variable
+
+The usage of an environmental variable allows for better flexibility when dealing with CI systems.
+
+The usage inside of your dist files will not change, but you can pass ENV as of your `go generate` command.
+
+Example:
+```shell script
+ DIST_FILE="https://raw.githubusercontent.com/chef/go-libs/master/distgen/tiny_glob_dist.json" go generate
+```

--- a/distgen/README.md
+++ b/distgen/README.md
@@ -46,12 +46,12 @@ package dist
 
 ### Using an Environment Variable
 
-The usage of an environmental variable allows for better flexibility when dealing with CI systems.  
+Using an environmental variable gives you more flexibility with CI systems.  
 The usage of an environmental variable allows for better flexibility when dealing with
-CI systems. As we saw in the previous example, the 3rd argument that is passed to
-`go run` is a URI, which is used to override the default JSON file for `distgen`. The
-`DIST_FILE` environment performs the same functionality by overloading the default
-JSON file. The usage inside of your dist files will not change, but you can pass ENV
+As we saw in the custom JSON file example, passing a URI to `go run` in the third argument 
+overrides the default JSON file for `distgen`.
+The `DIST_FILE` environment performs the same function by overloading the default JSON file.
+The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
 as a part of your `go generate` command.
 
 Example:

--- a/distgen/README.md
+++ b/distgen/README.md
@@ -47,12 +47,10 @@ package dist
 ### Using an Environment Variable
 
 Using an environmental variable gives you more flexibility with CI systems.  
-The usage of an environmental variable allows for better flexibility when dealing with
 As we saw in the custom JSON file example, passing a URI to `go run` in the third argument 
 overrides the default JSON file for `distgen`.
 The `DIST_FILE` environment performs the same function by overloading the default JSON file.
 The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
-as a part of your `go generate` command.
 
 Example:
 ```shell script

--- a/distgen/README.md
+++ b/distgen/README.md
@@ -47,12 +47,12 @@ package dist
 ### Using an Environment Variable
 
 The usage of an environmental variable allows for better flexibility when dealing with CI systems.  
-
-As we saw in the previous example, the 3rd argument that is passed to `go run` is an URI, which is used to override the default JSON file for `distgen`.
-
-The `DIST_FILE` environment performs the same functionality by overloading the default JSON file.
-
-The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
+The usage of an environmental variable allows for better flexibility when dealing with
+CI systems. As we saw in the previous example, the 3rd argument that is passed to
+`go run` is a URI, which is used to override the default JSON file for `distgen`. The
+`DIST_FILE` environment performs the same functionality by overloading the default
+JSON file. The usage inside of your dist files will not change, but you can pass ENV
+as a part of your `go generate` command.
 
 Example:
 ```shell script

--- a/distgen/doc.go
+++ b/distgen/doc.go
@@ -56,5 +56,17 @@ global variables to generate. (See an example of a JSON file at
   package dist
   //go:generate go run github.com/chef/go-libs/distgen global.go dist https://example.com/path/to/glob_dist.json
 
+Using an Environment Variable
+
+The usage of an environmental variable allows for better flexibility when dealing with CI systems.
+
+As we saw in the previous example, the 3rd argument that is passed to `go run` is an URI, which is used to override the default JSON file for `distgen`.
+
+The `DIST_FILE` environment performs the same functionality by overloading the default JSON file.
+
+The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
+
+  DIST_FILE="https://raw.githubusercontent.com/chef/go-libs/master/distgen/tiny_glob_dist.json" go generate
+
 */
 package main // import "github.com/chef/go-libs/distgen"

--- a/distgen/doc.go
+++ b/distgen/doc.go
@@ -58,13 +58,12 @@ global variables to generate. (See an example of a JSON file at
 
 Using an Environment Variable
 
-The usage of an environmental variable allows for better flexibility when dealing with CI systems.
-
-As we saw in the previous example, the 3rd argument that is passed to `go run` is an URI, which is used to override the default JSON file for `distgen`.
-
-The `DIST_FILE` environment performs the same functionality by overloading the default JSON file.
-
-The usage inside of your dist files will not change, but you can pass ENV as a part of your `go generate` command.
+The usage of an environmental variable allows for better flexibility when dealing with
+CI systems. As we saw in the previous example, the 3rd argument that is passed to
+"go run" is a URI, which is used to override the default JSON file for distgen. The
+DIST_FILE environment performs the same functionality by overloading the default
+JSON file. The usage inside of your dist files will not change, but you can pass ENV
+as a part of your "go generate" command.
 
   DIST_FILE="https://raw.githubusercontent.com/chef/go-libs/master/distgen/tiny_glob_dist.json" go generate
 

--- a/distgen/doc.go
+++ b/distgen/doc.go
@@ -58,11 +58,11 @@ global variables to generate. (See an example of a JSON file at
 
 Using an Environment Variable
 
-Using an environmental variable gives you more flexibility with CI systems. As we saw
-in the custom JSON file example, passing a URI to "go run" in the third argument
-overrides the default JSON file for distgen. The DIST_FILE environment performs the same
+Using an environmental variable gives you more flexibility with CI systems. As we saw in
+the custom JSON file example, passing a URI to `go run` in the third argument overrides
+the default JSON file for `distgen`. The `DIST_FILE` environment performs the same
 function by overloading the default JSON file. The usage inside of your dist files will
-not change, but you can pass ENV as a part of your "go generate" command.
+not change, but you can pass ENV as a part of your `go generate` command.
 
   DIST_FILE="https://raw.githubusercontent.com/chef/go-libs/master/distgen/tiny_glob_dist.json" go generate
 

--- a/distgen/doc.go
+++ b/distgen/doc.go
@@ -58,12 +58,11 @@ global variables to generate. (See an example of a JSON file at
 
 Using an Environment Variable
 
-The usage of an environmental variable allows for better flexibility when dealing with
-CI systems. As we saw in the previous example, the 3rd argument that is passed to
-"go run" is a URI, which is used to override the default JSON file for distgen. The
-DIST_FILE environment performs the same functionality by overloading the default
-JSON file. The usage inside of your dist files will not change, but you can pass ENV
-as a part of your "go generate" command.
+Using an environmental variable gives you more flexibility with CI systems. As we saw
+in the custom JSON file example, passing a URI to "go run" in the third argument
+overrides the default JSON file for distgen. The DIST_FILE environment performs the same
+function by overloading the default JSON file. The usage inside of your dist files will
+not change, but you can pass ENV as a part of your "go generate" command.
 
   DIST_FILE="https://raw.githubusercontent.com/chef/go-libs/master/distgen/tiny_glob_dist.json" go generate
 

--- a/distgen/main.go
+++ b/distgen/main.go
@@ -91,7 +91,7 @@ func main() {
 	}
 
 	file, ok := os.LookupEnv("DIST_FILE")
-	if ok != false {
+	if ok {
 		globDistJson = file
 	}
 

--- a/distgen/main.go
+++ b/distgen/main.go
@@ -90,6 +90,11 @@ func main() {
 		globDistJson = os.Args[3]
 	}
 
+	file, ok := os.LookupEnv("DIST_FILE")
+	if ok != false {
+		globDistJson = file
+	}
+
 	rsp, err := http.Get(globDistJson)
 	if err != nil {
 		fatal("failed to get global variables file", err)


### PR DESCRIPTION
This work allows the go generate command to have an environment variable `DIST_FILE`

fixes #18 

## Description
This work will look for an environmental variable called `DIST_FILE`, if it is able to find the variable, it will load the path into the `globDistJson` variable.

## Related Issue
#18 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
