### PR TITLE
Expose a foodcritic environment variable to enable deprecated usage

### DIFF
--- a/featflag/features.go
+++ b/featflag/features.go
@@ -82,8 +82,14 @@ var (
 		envName:   "CHEF_FEAT_ANALYZE",
 	}
 
+	// enables foodcritic usage in Chef Workstation
+	ChefFeatFoodcritic = Feature{
+		configKey: "foodcritic",
+		envName:   "CHEF_FEAT_FOODCRITIC",
+	}
+
 	// a list of all feature flags, global and local
-	featureFlags = []Feature{ChefFeatAll, ChefFeatAnalyze}
+	featureFlags = []Feature{ChefFeatAll, ChefFeatAnalyze, ChefFeatFoodcritic}
 
 	// config instance to access feature keys
 	cfg *config.Config


### PR DESCRIPTION
🚧 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
