### PR TITLE
Configuration support for Report Anonymization

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,11 +55,16 @@ type Config struct {
 	Connection    connSettings      `toml:"connection" mapstructure:"connection"`
 	Features      map[string]bool   `toml:"features" mapstructure:"features"`
 	Dev           devSettings       `toml:"dev" mapstructure:"dev"`
+	Reports       reportSettings    `toml:"reports" mapstructure:"reports"`
 }
 
 type telemetrySettings struct {
 	Enable bool `toml:"enable" mapstructure:"enable"`
 	Dev    bool `toml:"dev" mapstructure:"dev"`
+}
+
+type reportSettings struct {
+	Anonymize bool `toml:"anonymize" mapstructure:"anonymize"`
 }
 
 type logSettings struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,7 @@ func TestNewWithNoAppConfig(t *testing.T) {
 		assert.Equal(t, true, cfg.Features["foo"], "features is not well parsed")
 		assert.Equal(t, true, cfg.Features["bar"], "features is not well parsed")
 		assert.Equal(t, false, cfg.Features["xyz"], "features is not well parsed")
+		assert.Equal(t, true, cfg.Reports.Anonymize, "reports.anonymize is not well parsed")
 	}
 }
 
@@ -118,6 +119,7 @@ func TestNewOverrideFuncs(t *testing.T) {
 		assert.Equal(t, "ssh", cfg.Connection.DefaultProtocol, "connection.default_protocol is not well parsed")
 		assert.Equal(t, 3, len(cfg.Features), "features is not well parsed")
 		assert.Equal(t, true, cfg.Features["foo"], "features is not well parsed")
+		assert.Equal(t, true, cfg.Reports.Anonymize, "report anonymization was not overwritten")
 	}
 
 	cfg, err = subject.New(
@@ -133,6 +135,8 @@ func TestNewOverrideFuncs(t *testing.T) {
 		func(c *subject.Config) { c.Features["new"] = true },
 		// deactivate a new feature
 		func(c *subject.Config) { c.Features["foo"] = false },
+		// deactivate report anonymization
+		func(c *subject.Config) { c.Reports.Anonymize = false },
 	)
 	if assert.Nil(t, err) {
 		assert.Equal(t, false, cfg.Telemetry.Enable, "telemetry.enable was not overwritten")
@@ -142,6 +146,7 @@ func TestNewOverrideFuncs(t *testing.T) {
 		assert.Equal(t, 4, len(cfg.Features), "features was not overwritten")
 		assert.Equal(t, false, cfg.Features["foo"], "features was not overwritten")
 		assert.Equal(t, true, cfg.Features["new"], "features was not overwritten")
+		assert.Equal(t, false, cfg.Reports.Anonymize, "report anonymization was not overwritten")
 	}
 }
 
@@ -358,6 +363,9 @@ xyz = false
 
 [dev]
 spinner = true
+
+[reports]
+anonymize = true
 `)
 		userConfigFile = filepath.Join(
 			subject.DefaultChefWorkstationDirectory,
@@ -434,6 +442,9 @@ ws_app_feature = true
 abc = true
 xyz = true
 foo = false
+
+[reports]
+anonymize = true
 `)
 		appConfigFile = filepath.Join(
 			subject.DefaultChefWorkstationDirectory,
@@ -466,6 +477,9 @@ dev = true
 channel = "stable"
 
 [features]
+foo = "wrong"
+
+[reports]
 foo = "wrong"
 `)
 		appConfigFile = filepath.Join(
@@ -516,4 +530,8 @@ func assertSameInformationThatDoesntChangeOften(t *testing.T, cfg *subject.Confi
 
 	// test parsing of dev settings
 	assert.Equal(t, true, cfg.Dev.Spinner, "dev.spinner is not well parsed")
+
+	// test parsing of report settings
+	assert.Equal(t, true, cfg.Reports.Anonymize, "reports.anonymize is not well parsed")
+
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -119,7 +119,7 @@ func TestNewOverrideFuncs(t *testing.T) {
 		assert.Equal(t, "ssh", cfg.Connection.DefaultProtocol, "connection.default_protocol is not well parsed")
 		assert.Equal(t, 3, len(cfg.Features), "features is not well parsed")
 		assert.Equal(t, true, cfg.Features["foo"], "features is not well parsed")
-		assert.Equal(t, true, cfg.Reports.Anonymize, "report anonymization was not overwritten")
+		assert.Equal(t, true, cfg.Reports.Anonymize, "report anonymization is not well parsed")
 	}
 
 	cfg, err = subject.New(


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds a `[reports]` section in the configuration file for anonymization support.

```
[reports]
anonymize = true
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://app.zenhub.com/workspaces/chef-workstation-5c0aced04b5806bc2bfb9347/issues/chef/chef-analyze/287

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
