### PR TITLE
CHEF-27657 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright © 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,1 +1,1 @@
-Copyright © 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
+Copyright © 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ package main
 //go:generate go run github.com/chef/go-libs/distgen
 ```
 Look at the [distgen README](distgen/README.md) for more examples.
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/dist_gen.go
+++ b/config/dist_gen.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/finder.go
+++ b/config/finder.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/finder_test.go
+++ b/config/finder_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/workstation.go
+++ b/config/workstation.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/workstation_test.go
+++ b/config/workstation_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/credentials/dist_gen.go
+++ b/credentials/dist_gen.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/credentials/errors.go
+++ b/credentials/errors.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/doc.go
+++ b/distgen/doc.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-main/dist_gen.go
+++ b/distgen/example-main/dist_gen.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-main/dist_test.go
+++ b/distgen/example-main/dist_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-main/local.go
+++ b/distgen/example-main/local.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-main/main.go
+++ b/distgen/example-main/main.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-multi-pkg/cmd/main.go
+++ b/distgen/example-multi-pkg/cmd/main.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-multi-pkg/dist/dist_test.go
+++ b/distgen/example-multi-pkg/dist/dist_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-multi-pkg/dist/gen.go
+++ b/distgen/example-multi-pkg/dist/gen.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/example-multi-pkg/dist/local.go
+++ b/distgen/example-multi-pkg/dist/local.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/distgen/main.go
+++ b/distgen/main.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 // Source: https://github.com/afiune/godist
 // Documentation: https://godoc.org/github.com/chef/go-libs/distgen

--- a/featflag/dist_gen.go
+++ b/featflag/dist_gen.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/featflag/features.go
+++ b/featflag/features.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/featflag/features_test.go
+++ b/featflag/features_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/featflag/lookup.go
+++ b/featflag/lookup.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/featflag/lookup_test.go
+++ b/featflag/lookup_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Chef Software, Inc.
+// Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // Author: Salim Afiune <afiune@chef.io>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2019-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
